### PR TITLE
Support TensorFlow v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To install:
  $ pip install --user galsim-hub
 ```
 **Note**: GalSim-Hub currently assumes TensorFlow 1.15 to be installed, and will not try to install it as a dependency.
+If only TensorFlow 2.x is available, then it disables the v2 behaviour globally.
 
 
 ## Usage

--- a/galsim_hub/generative_model.py
+++ b/galsim_hub/generative_model.py
@@ -23,6 +23,11 @@ TODO: add more documentation
 import galsim
 import numpy as np
 import tensorflow as tf
+if tf.__version__[0]=='2':
+    import tensorflow.compat.v1 as tf
+    # To make tf 2.0 compatible with tf1.0 code, we disable the tf2.0 functionalities
+    tf.disable_eager_execution()
+    tf.disable_v2_tensorshape()
 import tensorflow_hub as hub
 
 class GenerativeGalaxyModel(object):


### PR DESCRIPTION
I made some changes that made `galsim_hub` work with TensorFlow v2.1.0. For the moment this works, but if you'd rather not advertise to users about the compatibility with TensorFlow v2, you can skip the changes made to README.